### PR TITLE
use merge so empty objects don't kill settings

### DIFF
--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -25,7 +25,7 @@ module.exports = function(grunt, options) {
   object.package = grunt.file.readJSON(path.join(cwd, 'package.json'));
 
   if (options.config) {
-    grunt.util._.extend(object, options.config);
+    grunt.util._.merge(object, options.config);
   }
 
   if (options.loadGruntTasks !== false) {

--- a/test/load-config.test.js
+++ b/test/load-config.test.js
@@ -9,7 +9,7 @@ suite('load-config', function() {
 
     var gruntOptions;
     setup(function() {
-      gruntOptions = loadConfig(grunt, { init: false, config: { debug: true } });
+      gruntOptions = loadConfig(grunt, { init: false, config: { debug: true, jshint: {} } });
     });
 
     test('read ', function() {
@@ -40,6 +40,7 @@ suite('load-config', function() {
 
       assert.equal(typeof gruntOptions.debug, 'boolean');
       assert.ok(gruntOptions.debug);
+      assert.ok(gruntOptions.jshint.all);
 
     });
 


### PR DESCRIPTION
Switched from [extend](http://lodash.com/docs#assign) to [merge](http://lodash.com/docs#merge) so that a config file can have defaults and the passed in `config` variable can overright any defaults without requring every property to be set.

Hypothetical pseudocode example:

jshint.json:

```
jshint: {
   // all these settings
}
```

and

`config` option

```
{
  jshint: {
    // i just want to overwrite one option, not replace the whole object.
  }
}
```
