### PR TITLE
ensure grunt.config is initialized.

### DIFF
--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -38,6 +38,9 @@ module.exports = function(grunt, options) {
     require('load-grunt-tasks')(grunt, loadTasksOptions);
   }
 
+  grunt.config.init(object); 
+
+
   if (options.init) {
     grunt.initConfig(object);
   }


### PR DESCRIPTION
I had real problems using grunt-environment with this module because it complained that grunt.config was null.

This gets around that problem.
