### PR TITLE
Added ability to share config between tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ load-grunt-config is a Grunt library that allows you to break up your Gruntfile 
 - Support for YAML files.
 - Support for coffeescript files.
 - Support for returning a function.
+- Support for sharing config properties between tasks
 - Easily register task aliases with `aliases.(js|yaml|coffee)`.
 
 ##Installation
@@ -70,14 +71,12 @@ module.exports = {
 
 Example js file returning a function - `grunt/jshint.js`
 ```javascript
-module.exports = function (grunt) {
+// the config parameter provides a reference to options.config
+module.exports = function (grunt, config) {
   return {
     all: [
-      'Gruntfile.js',
-      'grunt/*.js',
-      'lib/*.js',
-      'test/*.js'
-    ]
+      'Gruntfile.js'
+    ].concat(config.jsSrcFolders)
   };
 };
 ```

--- a/grunt/jshint.js
+++ b/grunt/jshint.js
@@ -1,10 +1,11 @@
-module.exports = function (grunt) {
+module.exports = function (grunt, config) {
   return {
     all: [
       'Gruntfile.js',
       'grunt/*.js',
       'lib/*.js',
       'test/*.js'
-    ]
+    ],
+    dummy: config.folders
   };
 };

--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -23,12 +23,12 @@ module.exports = function(grunt, options) {
       aliases = settings;
     } else {
       object[key] = grunt.util._.isFunction(settings) ?
-        settings(grunt) : settings;
+        settings(grunt, options.config) : settings;
     }
   });
 
   object.package = grunt.file.readJSON(path.join(cwd, 'package.json'));
-
+  
   if (options.config) {
     grunt.util._.merge(object, options.config);
   }

--- a/test/load-config.test.js
+++ b/test/load-config.test.js
@@ -9,7 +9,7 @@ suite('load-config', function() {
 
     var gruntOptions;
     setup(function() {
-      gruntOptions = loadConfig(grunt, { init: false, config: { debug: true, jshint: {} } });
+      gruntOptions = loadConfig(grunt, { init: false, config: { debug: true, jshint: {}, folders: ['dummy'] } });
     });
 
     test('read ', function() {
@@ -42,6 +42,12 @@ suite('load-config', function() {
       assert.ok(gruntOptions.debug);
       assert.ok(gruntOptions.jshint.all);
 
+    });
+    
+    test('shared config passing ', function() {
+
+      assert.equal(gruntOptions.jshint.dummy[0], 'dummy');
+      
     });
 
     test('load-grunt-tasks');


### PR DESCRIPTION
Using grunt's support for `<% %>` in the config it's possible to share strings in the config between tasks, but to share more complex objects (for instance, in a project of mine several tasks need access to an array of objects specifying bower dependencies and their main js files) it's useful to pass the config in to the task as a parameter.
