### PR TITLE
aliases file can now contain functions that need access grunt object

### DIFF
--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -48,7 +48,8 @@ module.exports = function(grunt, options) {
 
   if (aliases) {
     for (var taskName in aliases) {
-      grunt.registerTask(taskName, aliases[taskName]);
+      var task = aliases[taskName];
+      grunt.registerTask(taskName, _.isFunction(task) ? task(grunt) : task);
     }
   }
 


### PR DESCRIPTION
I duplicated a bit of your logic to enable the aliases file to contain function definitions that need access to the grunt object.

As an example, 

``` javascript
module.exports = {
  'default': function (grunt) {
    grunt.log.error('This task has been disabled!');
  },
  task1: [
    'thingOne',
    'thingTwo'
  ]
};
```

Due to the simplicity of the change, I did not add a test. You currently have `aliases.yml`, so I didn't want to remove and/or mess with it. With this change, your tests still succeed.
