### PR TITLE
LiveScript file support

### DIFF
--- a/lib/readconfigdir.js
+++ b/lib/readconfigdir.js
@@ -12,7 +12,7 @@ module.exports = function(dir, grunt, options) {
     return base;
   };
 
-  var files = glob.sync('*.{js,yml,yaml,coffee}', { cwd: dir });
+  var files = glob.sync('*.{js,yml,yaml,coffee,ls}', { cwd: dir });
 
   var fullPaths = files.map(function(file) {
     return path.join(dir, file);

--- a/lib/readfile.js
+++ b/lib/readfile.js
@@ -18,7 +18,7 @@ module.exports = function(file) {
     }
 
     // JS / JSON / CoffeeScript
-    if (ext.match(/json|js|coffee/)) {
+    if (ext.match(/json|js|coffee|ls/)) {
         return require(file);
     }
 


### PR DESCRIPTION
I think it deserves to be merged )
And the only string you need to add to the root Gruntfile.js is `require("LiveScript")`
