### PR TITLE
Allow group config files to return a function.

### DIFF
--- a/lib/readconfigdir.js
+++ b/lib/readconfigdir.js
@@ -22,6 +22,10 @@ module.exports = function(dir, grunt, options) {
   fullPaths.forEach(function(path) {
     var result = readfile(path);
     var key = getKey(path);
+    if (_.isFunction(result)) {
+      result = result(grunt, options);
+    }
+
     //check if multi config
     if (key.match(/-tasks$/)) {
       var target = key.replace(/-tasks$/, '');
@@ -32,9 +36,6 @@ module.exports = function(dir, grunt, options) {
         obj[newKey][target] = result[newKey];
       }
     } else {
-      if (_.isFunction(result)) {
-        result = result(grunt, options);
-      }
       if (!obj[key]) {
         obj[key] = {};
       }

--- a/test/fixtures/multiconfig/jsfun-tasks.js
+++ b/test/fixtures/multiconfig/jsfun-tasks.js
@@ -1,0 +1,8 @@
+module.exports = function(grunt, options) {
+  return {
+    copy: {
+      src: '*.js',
+      dest: 'build'
+    }
+  };
+};

--- a/test/fixtures/output/multiconfig.js
+++ b/test/fixtures/output/multiconfig.js
@@ -28,5 +28,11 @@ module.exports = {
         'html'
       ]
     }
+  },
+  copy: {
+    jsfun: {
+      src: '*.js',
+      dest: 'build'
+    }
   }
 };


### PR DESCRIPTION
Previously only single config files could return a function and
group config files were restricted to an object.
