### PR TITLE
Allow just-in-time loading

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var cwd = process.cwd();
 var defaults = {
   configPath: path.join(cwd, 'grunt'),
   init: true,
+  jitGrunt: false,
   loadGruntTasks: {
   },
   data: {}
@@ -36,8 +37,10 @@ module.exports = function(grunt, options) {
     grunt.initConfig(config);
   }
 
-  if (opts.loadGruntTasks) {
+  if (opts.jitGrunt === false && opts.loadGruntTasks) {
     require('load-grunt-tasks')(grunt, opts.loadGruntTasks);
+  } else if (opts.jitGrunt) {
+    require('jit-grunt')(grunt, opts.jitGrunt);
   }
 
   if (config.aliases) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "glob": "~3.2.6",
     "js-yaml": "~3.0.1",
     "load-grunt-tasks": "~0.3.0",
+    "jit-grunt": "~0.7.0",
     "lodash-node": "~2.4.1",
     "async": "~0.2.10"
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -25,6 +25,7 @@ suite('index', function() {
   };
   var gruntConfigSpy = sinon.spy(gruntConfigStub);
   var loadGruntTasksSpy = sinon.spy();
+  var jitGruntSpy = sinon.spy();
 
   setup(function(done) {
     original = loadGruntConfig;
@@ -32,7 +33,8 @@ suite('index', function() {
     //hijack gruntConfig lib and just return back the options so we can test just the loadGruntConfig module
     loadGruntConfig = proxyquire('../', {
       './lib/gruntconfig': gruntConfigSpy,
-      'load-grunt-tasks': loadGruntTasksSpy
+      'load-grunt-tasks': loadGruntTasksSpy,
+      'jit-grunt': jitGruntSpy
     });
     done();
 
@@ -44,6 +46,7 @@ suite('index', function() {
     grunt.registerTask.reset();
     gruntConfigSpy.reset();
     loadGruntTasksSpy.reset();
+    jitGruntSpy.reset();
     done();
   });
 
@@ -169,8 +172,52 @@ suite('index', function() {
       });
       assert.ok(loadGruntTasksSpy.notCalled);
     });
+
+    test('should not call if jitGrunt config specified', function() {
+      loadGruntConfig(grunt, {
+        configPath: 'test/config',
+        jitGrunt: {}
+      });
+      assert.ok(loadGruntTasksSpy.notCalled);
+    });
   });
 
+  suite('jit-grunt', function() {
+    test('should not call by default', function() {
+      loadGruntConfig(grunt, {
+        configPath: 'test/config'
+      });
+      assert.ok(jitGruntSpy.notCalled);
+    });
+
+    test('should call if jitGrunt config specified', function() {
+      loadGruntConfig(grunt, {
+        configPath: 'test/config',
+        jitGrunt: {}
+      });
+      assert.ok(jitGruntSpy.called);
+      var args = jitGruntSpy.args[0];
+      assert.ok(args.length, 2);
+    });
+
+    test('should call if jitGrunt: true', function() {
+      loadGruntConfig(grunt, {
+        configPath: 'test/config',
+        jitGrunt: true
+      });
+      assert.ok(jitGruntSpy.called);
+      var args = jitGruntSpy.args[0];
+      assert.ok(args.length, 2);
+    });
+
+    test('should not call if jitGrunt: false and gruntLoadTasks: false', function() {
+      loadGruntConfig(grunt, {
+        configPath: 'test/config',
+        jitGrunt: false
+      });
+      assert.ok(jitGruntSpy.notCalled);
+    });
+  });
 
   suite('aliases', function() {
     test('should registerTask for each alias', function() {


### PR DESCRIPTION
PR for #42
#### To use jit-grunt instead of load-grunt-tasks plugin, just set `jitGrunt: true`

``` js
require('load-grunt-config')(grunt, {
  jitGrunt: true
});
```

or specify `jitGrunt: {}` configuration object 

``` js
require('load-grunt-config')(grunt, {
  jitGrunt: {
    // jit-grunt configuration here (can be just empty object)
  }
});
```

This change should not affect current users.
#### Note:

jit-grunt is using task name to find and load grunt plugins, so in some cases you will need to specify [static mappings](https://github.com/shootaroo/jit-grunt#static-mappings).

**For example:**

``` js
jitGrunt: {
    simplemocha: 'grunt-simple-mocha'
}
```
