### PR TITLE
Adding new feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,10 +44,22 @@ module.exports = function(grunt, options) {
   }
 
   if (config.aliases) {
-    for (var taskName in config.aliases) {
-      grunt.registerTask(taskName, config.aliases[taskName]);
-    }
+    var getTaskRunner = function (tasks) {
+      return function () {
+        grunt.task.run(tasks);
+      };
+    };
 
+    for (var taskName in config.aliases) {
+      var task = config.aliases[taskName];
+
+      if (typeof task === 'string' || Array.isArray(task)){
+        grunt.registerTask(taskName, task);
+      }
+      else {
+        grunt.registerTask(taskName, task.description, getTaskRunner(task.tasks));
+      }
+    }
   }
 
   return config;

--- a/test/config/aliases.yaml
+++ b/test/config/aliases.yaml
@@ -1,2 +1,7 @@
 default:
   - 'test'
+anotherTask:
+  description: 'This is an awesome task'
+  tasks:
+    - 'foo'
+    - 'bar'

--- a/test/fixtures/output.js
+++ b/test/fixtures/output.js
@@ -2,7 +2,14 @@ module.exports = {
   aliases: {
     default: [
       'test'
-    ]
+    ],
+    anotherTask: {
+      description: 'This is an awesome task',
+      tasks: [
+        'foo',
+        'bar'
+      ]
+    }
   },
   coffeefile: {
     coffeeFile: {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -224,10 +224,22 @@ suite('index', function() {
       loadGruntConfig(grunt, {
         configPath: 'test/config'
       });
-      assert.equal(grunt.registerTask.callCount, 1);
+      assert.equal(grunt.registerTask.callCount, 2);
       var args = grunt.registerTask.args[0];
       assert.equal(args[0], 'default');
       assert.deepEqual(args[1], ['test']);
+    });
+    test('should pass the description if it\'s available', function () {
+      loadGruntConfig(grunt, {
+        configPath: 'test/config'
+      });
+      assert.equal(grunt.registerTask.callCount, 2);
+
+      var args = grunt.registerTask.args[1];
+
+      assert.equal(args[0], 'anotherTask');
+      assert.equal(args[1], 'This is an awesome task');
+      assert.equal(typeof args[2], 'function');
     });
   });
 


### PR DESCRIPTION
Now it's possible to add a description to an alias. That will be passed to Grunt.

For example:

```
default:
  - 'test'
anotherTask:
  description: 'This is an awesome task'
  tasks:
    - 'foo'
    - 'bar'
```

Will then be passed to grunt so running `grunt --help` will show the description.

> Note that the syntax is not exactly the same as proposed in #39 since `registerTask`, when receiving three parameters, receive a function and not a task list according to [their documentation](http://gruntjs.com/api/grunt.task#grunt.task.registertask). 

Fixes #39
