### PR TITLE
Alises to functions fail since version 0.11.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = function(grunt, options) {
     for (var taskName in config.aliases) {
       var task = config.aliases[taskName];
 
-      if (typeof task === 'string' || Array.isArray(task)){
+      if (typeof task === 'string' || typeof task === 'function' || Array.isArray(task)){
         grunt.registerTask(taskName, task);
       }
       else {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -238,6 +238,7 @@ suite('index', function() {
       assert.equal(args[0], 'default');
       assert.deepEqual(args[1], ['test']);
     });
+
     test('should pass the description if it\'s available', function () {
       loadGruntConfig(grunt, {
         configPath: 'test/config'
@@ -249,6 +250,35 @@ suite('index', function() {
       assert.equal(args[0], 'anotherTask');
       assert.equal(args[1], 'This is an awesome task');
       assert.equal(typeof args[2], 'function');
+    });
+
+    test('should support aliases to functions', function () {
+      // Override the loadGruntConfig created at setup
+      // Note the alternative of adding the alias into the fixture, implies lots
+      // of changes in other tests
+      var fnAliasFixture = {
+        aliases: {
+          aliasToFn: function () { return "A function"; }
+        }
+      };
+
+      loadGruntConfig = proxyquire('../', {
+        './lib/gruntconfig': function(grunt, options) {
+          return fnAliasFixture;
+        },
+        'load-grunt-tasks': loadGruntTasksSpy,
+        'jit-grunt': jitGruntSpy
+      });
+
+      loadGruntConfig(grunt, {
+        configPath: 'test/config'
+      });
+
+      assert.equal(grunt.registerTask.callCount, 1);
+      var args = grunt.registerTask.args[0];
+
+      assert.equal(args[0], 'aliasToFn');
+      assert.equal(typeof args[1], 'function');
     });
   });
 


### PR DESCRIPTION
For versions <= 0.10.0 it was possible to create an alias to a function. The regression was introduced by https://github.com/firstandthird/load-grunt-config/commit/665ce854afa48540f11e0ff49872af35fd0e1760#diff-d41d8cd98f00b204e9800998ecf8427e

To reproduce, create an alias to a function:

aliases.coffee:

``` coffee
module.exports =
    someAlias: () -> 'Do something'
```

If you run that alias with grunt, the following message appears:

```

Running "someAlias" task
Warning: Task "undefined" not found. Use --force to continue.
```

This PR fixes that regression, and adds a unit test for it.
The unit test needs to overwrite the `loadGruntConfig` mock set at `setup` to avoid more changes in other tests.
