### PR TITLE
Fixed issue with passing options to jit-grunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,19 @@ module.exports = function(grunt) {
 
 	require('load-grunt-config')(grunt, {
 		// ...
-		jitGrunt: { 
-			//here you can pass options to jit-grunt (or just jitGrunt: true)
+		jitGrunt: {
+		    // here you can pass options to jit-grunt (or just jitGrunt: true)
+		    staticMappings: {
+		        // here you can specify static mappings, for example:
+		        sprite: 'grunt-spritesmith',
+                hello: 'custom/say-hello.js'
+		    }
 		}
 	});
 
 };
 ```
+
 Note: if you have problems with auto loading of some tasks please check [jit-grunt#static-mappings](https://github.com/shootaroo/jit-grunt#static-mappings)
 
 ###Grunt tasks files

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = function(grunt, options) {
   if (opts.jitGrunt === false && opts.loadGruntTasks) {
     require('load-grunt-tasks')(grunt, opts.loadGruntTasks);
   } else if (opts.jitGrunt) {
-    require('jit-grunt')(grunt, opts.jitGrunt);
+    require('jit-grunt')(grunt, opts.jitGrunt.staticMappings)(opts.jitGrunt);
   }
 
   if (config.aliases) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "glob": "~3.2.6",
     "js-yaml": "~3.0.1",
     "load-grunt-tasks": "~0.3.0",
-    "jit-grunt": "~0.7.0",
+    "jit-grunt": "~0.8.0",
     "lodash-node": "~2.4.1",
     "async": "~0.2.10"
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -25,7 +25,10 @@ suite('index', function() {
   };
   var gruntConfigSpy = sinon.spy(gruntConfigStub);
   var loadGruntTasksSpy = sinon.spy();
-  var jitGruntSpy = sinon.spy();
+  var jitGruntStub = function(grunt, mappings) {
+    return function(options) {};
+  };
+  var jitGruntSpy = sinon.spy(jitGruntStub);
 
   setup(function(done) {
     original = loadGruntConfig;
@@ -222,8 +225,10 @@ suite('index', function() {
     test('should not call if jitGrunt: false and gruntLoadTasks: false', function() {
       loadGruntConfig(grunt, {
         configPath: 'test/config',
+        loadGruntTasks: false,
         jitGrunt: false
       });
+      assert.ok(loadGruntTasksSpy.notCalled);
       assert.ok(jitGruntSpy.notCalled);
     });
   });


### PR DESCRIPTION
Hi @jgallen23

This is fix for #82, but it can be a breaking change because it changes the way of passing static mappings to `jit-grunt`.

previously:

``` javascript
jitGrunt: {
    // static mappings
}
```

after:

``` javascript
jitGrunt: {
    // options
    staticMappings: {
        // static mappings
    }
}
```

Also I made all needed changes to `README.md`
