### PR TITLE
Aliases to functions when the alias is an object with a description

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,11 +78,22 @@ module.exports = function(grunt, options) {
     for (var taskName in config.aliases) {
       var task = config.aliases[taskName];
 
-      if (typeof task === 'string' || typeof task === 'function' || Array.isArray(task)){
+      // The task variable contains the task to register, the alias has no description
+      if (typeof task === 'string' || typeof task === 'function' || Array.isArray(task)) {
         grunt.registerTask(taskName, task);
-      }
-      else {
-        grunt.registerTask(taskName, task.description, getTaskRunner(task.tasks));
+
+      // The task variable is an object with two properties: tasks and description 
+      } else {
+
+        //  * The tasks property is a function, it can be register directly using registerTask
+        if (typeof task.tasks === 'function') {
+          grunt.registerTask(taskName, task.description, task.tasks);
+
+        //  * The tasks property is not a function, it must be wrapped inside one
+        } else {
+          grunt.registerTask(taskName, task.description, getTaskRunner(task.tasks));  
+        }
+
       }
     }
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -298,6 +298,38 @@ suite('index', function() {
       assert.equal(args[0], 'aliasToFn');
       assert.equal(typeof args[1], 'function');
     });
+
+    test('should support aliases to functions with description', function () {
+      // Same strategy as before
+      var fnAliasFixture = {
+        aliases: {
+          aliasToFn: {
+            'description' : 'This is an awesome task',
+            'tasks' : function () { return "A function"; }
+          }
+        }
+      };
+
+      loadGruntConfig = proxyquire('../', {
+        './lib/gruntconfig': function(grunt, options) {
+          return fnAliasFixture;
+        },
+        'load-grunt-tasks': loadGruntTasksSpy,
+        'jit-grunt': jitGruntSpy
+      });
+
+      loadGruntConfig(grunt, {
+        configPath: 'test/config'
+      });
+
+      assert.equal(grunt.registerTask.callCount, 1);
+      var args = grunt.registerTask.args[0];
+
+      assert.equal(args[0], 'aliasToFn');
+      assert.equal(args[1], 'This is an awesome task');
+      assert.equal(typeof args[2], 'function');
+      assert.equal(args[2](), 'A function');
+    });
   });
 
 });


### PR DESCRIPTION
Related to #80 and #73 

#80 allow function task in aliases.js. However, when the alias has a description, function task does not work. 
#73 fix this problem but was closed in favor of #80 due to better test strategy.

Like #73, this PR supports function tasks with description using aliases.js
but follow the strategy of #80 for unit test.
Some comments are added to this part of the code.

```
// aliases.js
module.exports = {
  myAlias: {
    description: 'Description of myAlias.',
    tasks: function (target) {
      // Function tasks here...
    }
  }
};
```