### PR TITLE
[suggestion] use config-extend instead of _.merge by default

### DIFF
--- a/lib/gruntconfig.js
+++ b/lib/gruntconfig.js
@@ -1,8 +1,9 @@
 var readConfigDir = require('./readconfigdir');
 var _ = require('lodash');
+var extend = require('config-extend');
 
 module.exports = function(grunt, options) {
-  var merge = options.mergeFunction || _.merge;
+  var merge = options.mergeFunction || extend;
   return _([[options.configPath], [options.overridePath]])
     .flatten()
     .compact()

--- a/lib/readconfigdir.js
+++ b/lib/readconfigdir.js
@@ -3,6 +3,7 @@ var async = require('async');
 var readfile = require('./readfile');
 var path = require('path');
 var _ = require('lodash');
+var extend = require('config-extend');
 
 module.exports = function(dir, grunt, options) {
 
@@ -14,7 +15,7 @@ module.exports = function(dir, grunt, options) {
 
   var files = glob.sync('*.{js,json,yml,yaml,cson,coffee,ls}', { cwd: dir });
 
-  var merge = options && options.mergeFunction || _.merge;
+  var merge = options && options.mergeFunction || extend;
 
   var obj = {};
   files.forEach(function(file) {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "async": "~0.2.10",
+    "config-extend": "^0.1.0",
     "cson": "~3.0.1",
     "glob": "~3.2.6",
     "jit-grunt": "~0.9.1",


### PR DESCRIPTION
It took me a while today to figure out that when arrays were extended by `_.merge` they were basically replaced positionally. So, if I had one array for `src` that had 5 files in it and tried to replace it via `overrideConfig` with a task that had a `src` with 1 file, it ended up replacing the first item in `src` and keeping the other 4, when really the whole `src` array should have been replaced.

I fixed this locally using `mergeFunction` but feel like the default behavior should be changed since right now I don't think it is doing what most people would expect it to do out of the box.

This update didn't break any tests, because there are no tests covering this situation. This is a minor behavioral change though so it should probably be a minor version bump if merged. If you'd be in favor of merging I can try and update the tests to cover this and prevent reversion.
