### PR TITLE
Ignoring files for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
   "bugs": {
     "url": "https://github.com/firstandthird/load-grunt-config/issues"
   },
+  "files": [
+    "lib",
+    "index.js"
+  ],
   "devDependencies": {
     "grunt-simple-mocha": "~0.4.0",
     "grunt-contrib-jshint": "~0.11.3",


### PR DESCRIPTION
Excludes unnecessary files from redist package. The average user does
not need tests in the package. They need developers.

About [README.md and LICENSE](https://docs.npmjs.com/files/package.json#files):
> Certain files are always included, regardless of settings:
>   * package.json
>   * README (and its variants)
>   * CHANGELOG (and its variants)
>   * LICENSE / LICENCE