### PR TITLE
Use array for default value of configPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var _ = require('lodash');
 
 var cwd = process.cwd();
 var defaults = {
-  configPath: path.join(cwd, 'grunt'),
+  configPath: [ path.join(cwd, 'grunt') ],
   init: true,
   jitGrunt: false,
   loadGruntTasks: {


### PR DESCRIPTION
Currently if I configure "configPath" as an array, merging it with the default values results in an array like this:

```
[
  '/my/path1',
  '/my/path2';
  'a',
  'r',
  '/',
  'w'
// ...
]
```

Because the string is treated as an array of characters, when used as array.

(I'm running node.js 5.0.0 if that matters)