### PR TITLE
Update jit-grunt dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "cson": "~3.0.2",
     "glob": "~5.0.15",
-    "jit-grunt": "~0.9.1",
+    "jit-grunt": "~0.10.0",
     "js-yaml": "~3.4.3",
     "load-grunt-tasks": "~3.3.0",
     "lodash": "~3.10.1"


### PR DESCRIPTION
Update the jit-grunt dependency to `~0.10.0` which includes the peerDependency update needed for Grunt v1.0.0. As that version has been released yesterday this results in a warning upon updating grunt to v1.0.0. Bumping the dependency should fix it.