### PR TITLE
Update load-grunt-tasks to allow for NPM 3 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "glob": "~5.0.15",
     "jit-grunt": "~0.10.0",
     "js-yaml": "~3.4.3",
-    "load-grunt-tasks": "~3.3.0",
+    "load-grunt-tasks": "~3.5.0",
     "lodash": "~3.10.1"
   }
 }


### PR DESCRIPTION
Updates the load-grunt-tasks dependency so that users can pass in `requireResolution:true` in the `loadGruntTasks` option to allow for NPM 3 support - the flattened file structure often interferes otherwise.