### PR TITLE
Support .cjs files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ load-grunt-config is a Grunt library that allows you to break up your Gruntfile 
 - Support for YAML files.
 - Support for CSON files.
 - Support for returning a function.
-- [Easily register task aliases](#aliases) with `aliases.(js|json|yaml)`.
+- [Easily register task aliases](#aliases) with `aliases.(js|cjs|json|yaml)`.
 - [Config overrides](#custom-config)
 - [Config grouping](#config-grouping)
 

--- a/lib/readconfigdir.js
+++ b/lib/readconfigdir.js
@@ -11,7 +11,7 @@ module.exports = function(dir, grunt, options) {
     return base;
   };
 
-  var files = glob.sync('*.{js,json,yml,yaml,cson,ls}', { cwd: dir });
+  var files = glob.sync('*.{js,cjs,json,yml,yaml,cson,ls}', { cwd: dir });
 
   var merge = options && options.mergeFunction || _.merge;
 

--- a/test/config/cjsfun.cjs
+++ b/test/config/cjsfun.cjs
@@ -1,0 +1,10 @@
+module.exports = function (grunt, options) {
+  return {
+    cjsFunFile: {
+      options: {
+        filename: 'cjsfun.cjs',
+        test: options.test
+      }
+    }
+  };
+};

--- a/test/config/cjsobj.cjs
+++ b/test/config/cjsobj.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  cjsobjFile: {
+    options: {
+      filename: 'cjsobj.cjs',
+      debug: true
+    }
+  }
+};

--- a/test/fixtures/output.js
+++ b/test/fixtures/output.js
@@ -27,6 +27,22 @@ module.exports = {
       }
     }
   },
+  cjsfun: {
+    cjsFunFile: {
+      options: {
+        filename: 'cjsfun.cjs',
+        test: 1
+      }
+    }
+  },
+  cjsobj: {
+    cjsobjFile: {
+      options: {
+        filename: 'cjsobj.cjs',
+        debug: true
+      }
+    }
+  },
   jsonfile: {
     jsonFile: {
       options: {
@@ -41,7 +57,7 @@ module.exports = {
         filename: 'read.cson'
       }
     }
-  },  
+  },
   yamlfile: {
     yamlFile: {
       options: {

--- a/test/gruntconfig.test.js
+++ b/test/gruntconfig.test.js
@@ -231,7 +231,7 @@ suite('gruntConfig', function() {
       ]
     };
     gruntConfig(grunt, options);
-    assert.equal(spy.callCount, 8);
+    assert.equal(spy.callCount, 10);
   });
 
 });

--- a/test/readconfigdir.test.js
+++ b/test/readconfigdir.test.js
@@ -25,7 +25,7 @@ suite('readConfigDir', function() {
     };
 
     readConfigDir(__dirname+'/config', grunt, options);
-    assert.equal(spy.callCount, 7);
+    assert.equal(spy.callCount, 9);
   });
 
   test('multiconfig', function() {

--- a/test/readfile.test.js
+++ b/test/readfile.test.js
@@ -48,6 +48,20 @@ suite('readfile', function() {
     assert.equal(obj.jsFunFile.options.test, 1);
   });
 
+  test('read cjs object file', function() {
+    var json = readfile(__dirname+'/config/cjsobj.cjs');
+    assert.equal(json.cjsobjFile.options.filename, 'cjsobj.cjs');
+  });
+
+  test('read cjs file with function, returns function', function() {
+    var fn = readfile(__dirname+'/config/cjsfun.cjs');
+    assert.equal(typeof fn, 'function');
+    //fn takes two args, grunt and options
+    var obj = fn({}, { test: 1 });
+    assert.equal(obj.cjsFunFile.options.filename, 'cjsfun.cjs');
+    assert.equal(obj.cjsFunFile.options.test, 1);
+  });
+
   test('read unsupported file', function() {
     assert.throws(function() {
       readfile(__dirname+'/config/htmlfile.html');


### PR DESCRIPTION
When migrating projects to ES modules (setting `"type": "module"` globally in `package.json`), 
then in order to leave the Grunt-related scripts CommonJS-based, those files need to have the `.cjs ` extension to still work.

This pull request makes `load-grunt-config` treat `.cjs` files just like `.js` files.

Related PR for Grunt itself: https://github.com/gruntjs/grunt/pull/1736